### PR TITLE
feat: add health metrics and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Import the grafana dashboard with id `23344`.
 
 ```
 $ curl localhost:9187/metrics
+# HELP masscan_collectors_total Reports the number of configured collectors.
+# TYPE masscan_collectors_total gauge
+masscan_collectors_total 2
 # HELP masscan_ports_open Masscan port status report
 # TYPE masscan_ports_open gauge
 masscan_ports_open{collector="network0",ip="10.0.0.1",port="179",proto="tcp",reason="syn-ack"} 1
@@ -36,6 +39,10 @@ masscan_scrape_collector_success{collector="network1"} 1
 # TYPE masscan_scrape_in_progress gauge
 masscan_scrape_in_progress{collector="network0"} 0
 masscan_scrape_in_progress{collector="network1"} 0
+# HELP masscan_scrape_next_start_time Reports the start time for the next scrape.
+# TYPE masscan_scrape_next_start_time gauge
+masscan_scrape_next_start_time{collector="network0"} 1.7456961000000699e+09
+masscan_scrape_next_start_time{collector="network1"} 1.7456961300006979e+09
 # HELP masscan_scrape_seconds Reports how long a scrape took in seconds.
 # TYPE masscan_scrape_seconds gauge
 masscan_scrape_seconds{collector="network0"} 67.674926113
@@ -44,6 +51,16 @@ masscan_scrape_seconds{collector="network1"} 66.65523849
 # TYPE masscan_scrape_start_time counter
 masscan_scrape_start_time{collector="network0"} 1.7456958000000699e+09
 masscan_scrape_start_time{collector="network1"} 1.7456958300006979e+09
+# HELP masscan_scrapes_failed_current The number of consecutive scrapes which have failed.
+# TYPE masscan_scrapes_failed_current gauge
+masscan_scrapes_failed_current{collector="network0"} 0
+masscan_scrapes_failed_current{collector="network1"} 0
+# HELP masscan_scrapes_total Total number of scrapes executed for the collector.
+# TYPE masscan_scrapes_total counter
+masscan_scrapes_total{collector="network0",result="failed"} 0
+masscan_scrapes_total{collector="network0",result="success"} 3
+masscan_scrapes_total{collector="network1",result="failed"} 0
+masscan_scrapes_total{collector="network1",result="success"} 3
 ```
 
 ### Example Config:
@@ -88,4 +105,7 @@ collectors:
 #     config: ""                  # provide a masscan config as a string
 server:
   listen: :9090 # default: :9090
+  # The number of times a collector can fail before /readyz will report unhealthy.
+  # default is 5, set to 0 to disable.
+  unhealthy_failed_scrapes: 5
 ```

--- a/internal/collector/descriptions.go
+++ b/internal/collector/descriptions.go
@@ -5,15 +5,21 @@ import "github.com/prometheus/client_golang/prometheus"
 var (
 	descScrapeSuccess    = prometheus.NewDesc("masscan_scrape_collector_success", "Reports if the scrape was successful.", []string{"collector"}, nil)
 	descScrapeStart      = prometheus.NewDesc("masscan_scrape_start_time", "Reports the start time of the scrape.", []string{"collector"}, nil)
+	descScrapeNextStart  = prometheus.NewDesc("masscan_scrape_next_start_time", "Reports the start time for the next scrape.", []string{"collector"}, nil)
 	descScrapeSeconds    = prometheus.NewDesc("masscan_scrape_seconds", "Reports how long a scrape took in seconds.", []string{"collector"}, nil)
 	descScrapeInProgress = prometheus.NewDesc("masscan_scrape_in_progress", "Reports if a scrape is in progress.", []string{"collector"}, nil)
+	descScrapesTotal     = prometheus.NewDesc("masscan_scrapes_total", "Total number of scrapes executed for the collector.", []string{"collector", "result"}, nil)
+	descScrapesFailed    = prometheus.NewDesc("masscan_scrapes_failed_current", "The number of consecutive scrapes which have failed.", []string{"collector"}, nil)
 	descPortsOpen        = prometheus.NewDesc("masscan_ports_open", "Masscan port status report", []string{"collector", "ip", "port", "proto", "reason"}, nil)
 )
 
 func Describe(ch chan<- *prometheus.Desc) {
 	ch <- descScrapeSuccess
 	ch <- descScrapeStart
+	ch <- descScrapeNextStart
 	ch <- descScrapeSeconds
 	ch <- descScrapeInProgress
+	ch <- descScrapesTotal
+	ch <- descScrapesFailed
 	ch <- descPortsOpen
 }

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -6,17 +6,32 @@ import (
 
 	"github.com/mikemrm/masscan-exporter/internal/collector"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+)
+
+var (
+	descCollectors = prometheus.NewDesc("masscan_collectors_total", "Reports the number of configured collectors.", nil, nil)
 )
 
 type exporter struct {
+	logger     *zerolog.Logger
 	collectors []*collector.Collector
 }
 
 func (e *exporter) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descCollectors
+
 	collector.Describe(ch)
 }
 
 func (e *exporter) Collect(ch chan<- prometheus.Metric) {
+	totalCollectors, err := prometheus.NewConstMetric(descCollectors, prometheus.GaugeValue, float64(len(e.collectors)))
+	if err != nil {
+		e.logger.Err(err).Msg("failed to create total collectors metric")
+	} else {
+		ch <- totalCollectors
+	}
+
 	for _, c := range e.collectors {
 		c.Collect(ch)
 	}
@@ -26,6 +41,7 @@ func New(ctx context.Context, opts ...Option) (prometheus.Collector, error) {
 	cfg := newConfig(opts...)
 
 	exporter := &exporter{
+		logger:     zerolog.Ctx(ctx),
 		collectors: cfg.Collectors,
 	}
 


### PR DESCRIPTION
A few new metrics have been added to give more insight into the health of the service.

- `masscan_collectors_total` reports how many collectors have been configured.
- `masscan_scrapes_total` reports the total number of scrapes executed for a particular collector, broken out by success and failed results.
- `masscan_scrapes_failed_current` reports the current number of consecutive failed scrapes. The value is reset upon a successful scrape.
- `masscan_scrape_next_start_time` reports the next time a scrape will occur.

In addition to the new metrics, `/livez` and `/readyz` endpoints were added.
- `/livez` always returns a 200 status code.
- `/readyz` will report a 200 status code if there is at least one collector configured and none of the collectors have exceeded an unhealthy number of scrapes.

The unhealthy number of failed scrapes may be configured by setting `server.unhealthy_failed_scrapes` in the config.
If no value is provided, `5` is used by default.
This can be disabled by setting the value to `0`.